### PR TITLE
Add Dokcer.io installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ provided.
 
     * admin.add_user: Adds user, its group can also be specified.
     * admin.add_swap: Adds a swap partition to the system.
+    * docker.install_docker: Installs Docker.
     * nginx.install_passenger: Installs nginx with passenger support.
     * node.install: Installs node.
     * postgresql.install: Installs PostgreSQL and its development packages.

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -39,6 +39,9 @@ assert vps
 from fabfile import java
 assert java
 
+from fabfile import docker
+assert docker
+
 """ Fabric global configuration """
 
 from fabric.api import env

--- a/fabfile/docker.py
+++ b/fabfile/docker.py
@@ -1,0 +1,40 @@
+# fabric
+from fabric.api import env
+from fabric.api import run
+from fabric.api import task
+from fabric.colors import green
+from fabric.contrib.files import append
+
+# fabtools
+from fabtools import deb
+from fabtools import user
+
+from fabfile import utils
+
+
+@task
+def install_docker():
+    # add pgp key
+    print(green('Adding PGP key'))
+    deb.add_apt_key(keyid='58118E89F3A912897C070ADBF76221572C52609D',
+                    keyserver='p80.pool.sks-keyservers.net')
+
+    # add https support for apt
+    utils.deb.install('apt-transport-https')
+
+    # obtain the LSB version name
+    id_, release, codename = run('lsb_release --id --release --codename --short').split("\r\n")
+
+    # add docker apt sources list
+    source = "deb https://apt.dockerproject.org/repo {}-{} main".format(id_.lower(), codename)
+    append('/etc/apt/sources.list.d/docker.list', source, use_sudo=True)
+    
+    # update apt index
+    deb.update_index(quiet=False)
+
+    # install docker.io
+    utils.deb.install('docker-engine')
+
+    # add current user to docker group
+    current_user = env.user
+    user.modify(current_user, extra_groups=['docker'])


### PR DESCRIPTION
New fabric task `docker.install_docker` to install docker on Debian or Ubuntu the right way.

What it does:
- Add docker's apt key
- Install https apt transport
- Add docker's apt sources
- Install `docker-engine`
- Add current user to `docker` group (so it doesn't need to run `sudo docker` everytime)
