### PR TITLE
Fix user group assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ provided.
 
     * admin.add_user: Adds user, its group can also be specified.
     * admin.add_swap: Adds a swap partition to the system.
-    * docker.install_docker: Installs Docker.
+    * docker.install: Installs Docker.
     * nginx.install_passenger: Installs nginx with passenger support.
     * node.install: Installs node.
     * postgresql.install: Installs PostgreSQL and its development packages.

--- a/fabfile/docker.py
+++ b/fabfile/docker.py
@@ -14,7 +14,7 @@ from fabfile import utils
 
 
 @task
-def install_docker():
+def install():
     # add pgp key
     print(green('Adding PGP key'))
     deb.add_apt_key(keyid='58118E89F3A912897C070ADBF76221572C52609D',

--- a/fabfile/docker.py
+++ b/fabfile/docker.py
@@ -1,6 +1,7 @@
 # fabric
 from fabric.api import env
 from fabric.api import run
+from fabric.api import sudo
 from fabric.api import task
 from fabric.colors import green
 from fabric.contrib.files import append
@@ -37,4 +38,5 @@ def install_docker():
 
     # add current user to docker group
     current_user = env.user
-    user.modify(current_user, extra_groups=['docker'])
+    cmd = "gpasswd -a {} docker".format(current_user)
+    sudo(cmd)


### PR DESCRIPTION
With `fabtools.user.modify` the list passed as `extra_groups` deleted any previous groups the user belonged to. I fixed it to just add the user to the group (using a `sudo` command, I didn't find any util in fabtools to get the current groups of a user).
